### PR TITLE
Remove styling to fix horizontal scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -612,8 +612,6 @@ pre code {
 .row {
   display: flex;
   flex-wrap: wrap;
-  margin-right: -15px;
-  margin-left: -15px;
 }
 
 .no-gutters {


### PR DESCRIPTION
Resolves the "always present scrollbar" locally for both wider screen and simulated mobile— from a suggestion at https://github.com/twbs/bootstrap/issues/10711