### PR TITLE
Use new colors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11,11 +11,14 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 :root {
-  --platefund-gray: #E2E5F0;
-  --platefund-red: #A32035;
-  --platefund-light-blue: #5472B6;
-  --platefund-dark-blue: #071E3C;
+  /* New Plate Fund color palette */
+  --pf-pale-aqua: #E2ECEE;
+  --pf-deep-aqua: #94dddb;
+  --pf-white: #FCF7FF;
+  --pf-dark-slate: #1F202A;
+  --pf-forest-blue: #08332C;
 
+  /* Bootstrap defaults */
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -29,7 +32,7 @@
   --white: #fff;
   --gray: #E2E5F0;
   --gray-dark: #343a40;
-  --primary: #425F3F:
+  --primary: #425F3F;
   --secondary: #6c757d;
   --success: #28a745;
   --info: #17a2b8;
@@ -69,9 +72,9 @@ body {
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
-  color: #212529;
+  color: var(--pf-dark-slate);
   text-align: left;
-  background-color: #E2E5F0;
+  background-color: var(--pf-pale-aqua);
 }
 
 [tabindex="-1"]:focus:not(:focus-visible) {
@@ -164,12 +167,12 @@ sup {
 }
 
 a {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   text-decoration: none;
   background-color: transparent;
 }
 a:hover {
-  color: #5472B6;
+  color: var(--pf-deep-aqua);
   text-decoration: underline;
 }
 
@@ -373,32 +376,32 @@ h1, h2, h3, h4, h5, h6,
 }
 
 h1, .h1 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 2.5rem;
 }
 
 h2, .h2 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 2rem;
 }
 
 h3, .h3 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 1.75rem;
 }
 
 h4, .h4 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 1.5rem;
 }
 
 h5, .h5 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 1.25rem;
 }
 
 h6, .h6 {
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-size: 1rem;
 }
 
@@ -493,7 +496,7 @@ mark,
 
 .img-thumbnail {
   padding: 0.25rem;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border: 1px solid #dee2e6;
   border-radius: 0.25rem;
   max-width: 100%;
@@ -526,8 +529,8 @@ a > code {
 kbd {
   padding: 0.2rem 0.4rem;
   font-size: 87.5%;
-  color: #fff;
-  background-color: #212529;
+  color: var(--pf-white);
+  background-color: var(--pf-dark-slate);
   border-radius: 0.2rem;
 }
 kbd kbd {
@@ -539,7 +542,7 @@ kbd kbd {
 pre {
   display: block;
   font-size: 87.5%;
-  color: #212529;
+  color: var(--pf-dark-slate);
 }
 pre code {
   font-size: inherit;
@@ -1689,7 +1692,7 @@ pre code {
 .table {
   width: 100%;
   margin-bottom: 1rem;
-  color: #212529;
+  color: var(--pf-dark-slate);
 }
 .table th,
 .table td {
@@ -1734,7 +1737,7 @@ pre code {
 }
 
 .table-hover tbody tr:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: rgba(0, 0, 0, 0.075);
 }
 
@@ -1913,7 +1916,7 @@ pre code {
 }
 
 .table .thead-dark th {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
   border-color: #454d55;
 }
@@ -1924,7 +1927,7 @@ pre code {
 }
 
 .table-dark {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
 }
 .table-dark th,
@@ -1939,7 +1942,7 @@ pre code {
   background-color: rgba(255, 255, 255, 0.05);
 }
 .table-dark.table-hover tbody tr:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: rgba(255, 255, 255, 0.075);
 }
 
@@ -2006,7 +2009,7 @@ pre code {
   font-weight: 400;
   line-height: 1.5;
   color: #495057;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: padding-box;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
@@ -2027,7 +2030,7 @@ pre code {
 }
 .form-control:focus {
   color: #495057;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border-color: #fbc2b3;
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
@@ -2059,7 +2062,7 @@ pre code {
 
 select.form-control:focus::-ms-value {
   color: #495057;
-  background-color: #fff;
+  background-color: var(--pf-white);
 }
 
 .form-control-file,
@@ -2097,7 +2100,7 @@ select.form-control:focus::-ms-value {
   margin-bottom: 0;
   font-size: 1rem;
   line-height: 1.5;
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: transparent;
   border: solid transparent;
   border-width: 1px 0;
@@ -2202,7 +2205,7 @@ textarea.form-control {
   margin-top: 0.1rem;
   font-size: 0.875rem;
   line-height: 1.5;
-  color: #fff;
+  color: var(--pf-white);
   background-color: rgba(40, 167, 69, 0.9);
   border-radius: 0.25rem;
 }
@@ -2235,7 +2238,7 @@ textarea.form-control {
 .was-validated .custom-select:valid, .custom-select.is-valid {
   border-color: #28a745;
   padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") var(--pf-white) no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .custom-select:valid:focus, .custom-select.is-valid:focus {
   border-color: #28a745;
@@ -2294,7 +2297,7 @@ textarea.form-control {
   margin-top: 0.1rem;
   font-size: 0.875rem;
   line-height: 1.5;
-  color: #fff;
+  color: var(--pf-white);
   background-color: rgba(220, 53, 69, 0.9);
   border-radius: 0.25rem;
 }
@@ -2327,7 +2330,7 @@ textarea.form-control {
 .was-validated .custom-select:invalid, .custom-select.is-invalid {
   border-color: #dc3545;
   padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") var(--pf-white) no-repeat center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .custom-select:invalid:focus, .custom-select.is-invalid:focus {
   border-color: #dc3545;
@@ -2428,7 +2431,7 @@ textarea.form-control {
 .btn {
   display: inline-block;
   font-weight: 400;
-  color: #212529;
+  color: var(--pf-dark-slate);
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
@@ -2450,7 +2453,7 @@ textarea.form-control {
   }
 }
 .btn:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   text-decoration: none;
 }
 .btn:focus, .btn.focus {
@@ -2466,28 +2469,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-primary {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
 .btn-primary:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f24516;
   border-color: #ee3e0d;
 }
 .btn-primary:focus, .btn-primary.focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f24516;
   border-color: #ee3e0d;
   box-shadow: 0 0 0 0.2rem rgba(246, 122, 88, 0.5);
 }
 .btn-primary.disabled, .btn-primary:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
 .btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active, .show > .btn-primary.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #ee3e0d;
   border-color: #e23a0d;
 }
@@ -2496,28 +2499,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-secondary {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #6c757d;
   border-color: #6c757d;
 }
 .btn-secondary:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #5a6268;
   border-color: #545b62;
 }
 .btn-secondary:focus, .btn-secondary.focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #5a6268;
   border-color: #545b62;
   box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
 }
 .btn-secondary.disabled, .btn-secondary:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #6c757d;
   border-color: #6c757d;
 }
 .btn-secondary:not(:disabled):not(.disabled):active, .btn-secondary:not(:disabled):not(.disabled).active, .show > .btn-secondary.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #545b62;
   border-color: #4e555b;
 }
@@ -2526,28 +2529,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-success {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #28a745;
   border-color: #28a745;
 }
 .btn-success:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #218838;
   border-color: #1e7e34;
 }
 .btn-success:focus, .btn-success.focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #218838;
   border-color: #1e7e34;
   box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
 }
 .btn-success.disabled, .btn-success:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #28a745;
   border-color: #28a745;
 }
 .btn-success:not(:disabled):not(.disabled):active, .btn-success:not(:disabled):not(.disabled).active, .show > .btn-success.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #1e7e34;
   border-color: #1c7430;
 }
@@ -2556,28 +2559,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-info {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #17a2b8;
   border-color: #17a2b8;
 }
 .btn-info:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #138496;
   border-color: #117a8b;
 }
 .btn-info:focus, .btn-info.focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #138496;
   border-color: #117a8b;
   box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
 }
 .btn-info.disabled, .btn-info:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #17a2b8;
   border-color: #17a2b8;
 }
 .btn-info:not(:disabled):not(.disabled):active, .btn-info:not(:disabled):not(.disabled).active, .show > .btn-info.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #117a8b;
   border-color: #10707f;
 }
@@ -2586,28 +2589,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-warning {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #ffc107;
   border-color: #ffc107;
 }
 .btn-warning:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #e0a800;
   border-color: #d39e00;
 }
 .btn-warning:focus, .btn-warning.focus {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #e0a800;
   border-color: #d39e00;
   box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
 }
 .btn-warning.disabled, .btn-warning:disabled {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #ffc107;
   border-color: #ffc107;
 }
 .btn-warning:not(:disabled):not(.disabled):active, .btn-warning:not(:disabled):not(.disabled).active, .show > .btn-warning.dropdown-toggle {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #d39e00;
   border-color: #c69500;
 }
@@ -2616,28 +2619,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-danger {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #dc3545;
   border-color: #dc3545;
 }
 .btn-danger:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #c82333;
   border-color: #bd2130;
 }
 .btn-danger:focus, .btn-danger.focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #c82333;
   border-color: #bd2130;
   box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);
 }
 .btn-danger.disabled, .btn-danger:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #dc3545;
   border-color: #dc3545;
 }
 .btn-danger:not(:disabled):not(.disabled):active, .btn-danger:not(:disabled):not(.disabled).active, .show > .btn-danger.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #bd2130;
   border-color: #b21f2d;
 }
@@ -2646,28 +2649,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-light {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #f8f9fa;
   border-color: #f8f9fa;
 }
 .btn-light:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #e2e6ea;
   border-color: #dae0e5;
 }
 .btn-light:focus, .btn-light.focus {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #e2e6ea;
   border-color: #dae0e5;
   box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);
 }
 .btn-light.disabled, .btn-light:disabled {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #f8f9fa;
   border-color: #f8f9fa;
 }
 .btn-light:not(:disabled):not(.disabled):active, .btn-light:not(:disabled):not(.disabled).active, .show > .btn-light.dropdown-toggle {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #dae0e5;
   border-color: #d3d9df;
 }
@@ -2676,28 +2679,28 @@ fieldset:disabled a.btn {
 }
 
 .btn-dark {
-  color: #fff;
-  background-color: #071E3C;
-  border-color: #071E3C;
+  color: var(--pf-white);
+  background-color: var(--pf-forest-blue);
+  border-color: var(--pf-forest-blue);
 }
 .btn-dark:hover {
-  color: #fff;
-  background-color: #5472B6;
+  color: var(--pf-white);
+  background-color: var(--pf-deep-aqua);
   border-color: #1d2124;
 }
 .btn-dark:focus, .btn-dark.focus {
-  color: #fff;
-  background-color:  #5472B6;
+  color: var(--pf-white);
+  background-color: var(--pf-deep-aqua);
   border-color: #1d2124;
   box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);
 }
 .btn-dark.disabled, .btn-dark:disabled {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
   border-color: #343a40;
 }
 .btn-dark:not(:disabled):not(.disabled):active, .btn-dark:not(:disabled):not(.disabled).active, .show > .btn-dark.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #1d2124;
   border-color: #171a1d;
 }
@@ -2710,7 +2713,7 @@ fieldset:disabled a.btn {
   border-color: #f4623a;
 }
 .btn-outline-primary:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
@@ -2722,7 +2725,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-primary:not(:disabled):not(.disabled):active, .btn-outline-primary:not(:disabled):not(.disabled).active, .show > .btn-outline-primary.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
@@ -2735,7 +2738,7 @@ fieldset:disabled a.btn {
   border-color: #6c757d;
 }
 .btn-outline-secondary:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #6c757d;
   border-color: #6c757d;
 }
@@ -2747,7 +2750,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active, .show > .btn-outline-secondary.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #6c757d;
   border-color: #6c757d;
 }
@@ -2760,7 +2763,7 @@ fieldset:disabled a.btn {
   border-color: #28a745;
 }
 .btn-outline-success:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #28a745;
   border-color: #28a745;
 }
@@ -2772,7 +2775,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success:not(:disabled):not(.disabled).active, .show > .btn-outline-success.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #28a745;
   border-color: #28a745;
 }
@@ -2785,7 +2788,7 @@ fieldset:disabled a.btn {
   border-color: #17a2b8;
 }
 .btn-outline-info:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #17a2b8;
   border-color: #17a2b8;
 }
@@ -2797,7 +2800,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-info:not(:disabled):not(.disabled):active, .btn-outline-info:not(:disabled):not(.disabled).active, .show > .btn-outline-info.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #17a2b8;
   border-color: #17a2b8;
 }
@@ -2810,7 +2813,7 @@ fieldset:disabled a.btn {
   border-color: #ffc107;
 }
 .btn-outline-warning:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #ffc107;
   border-color: #ffc107;
 }
@@ -2822,7 +2825,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-warning:not(:disabled):not(.disabled):active, .btn-outline-warning:not(:disabled):not(.disabled).active, .show > .btn-outline-warning.dropdown-toggle {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #ffc107;
   border-color: #ffc107;
 }
@@ -2835,7 +2838,7 @@ fieldset:disabled a.btn {
   border-color: #dc3545;
 }
 .btn-outline-danger:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #dc3545;
   border-color: #dc3545;
 }
@@ -2847,7 +2850,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-danger:not(:disabled):not(.disabled):active, .btn-outline-danger:not(:disabled):not(.disabled).active, .show > .btn-outline-danger.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #dc3545;
   border-color: #dc3545;
 }
@@ -2860,7 +2863,7 @@ fieldset:disabled a.btn {
   border-color: #f8f9fa;
 }
 .btn-outline-light:hover {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #f8f9fa;
   border-color: #f8f9fa;
 }
@@ -2872,7 +2875,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-light:not(:disabled):not(.disabled):active, .btn-outline-light:not(:disabled):not(.disabled).active, .show > .btn-outline-light.dropdown-toggle {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #f8f9fa;
   border-color: #f8f9fa;
 }
@@ -2885,7 +2888,7 @@ fieldset:disabled a.btn {
   border-color: #343a40;
 }
 .btn-outline-dark:hover {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
   border-color: #343a40;
 }
@@ -2897,7 +2900,7 @@ fieldset:disabled a.btn {
   background-color: transparent;
 }
 .btn-outline-dark:not(:disabled):not(.disabled):active, .btn-outline-dark:not(:disabled):not(.disabled).active, .show > .btn-outline-dark.dropdown-toggle {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
   border-color: #343a40;
 }
@@ -3014,10 +3017,10 @@ input[type=button].btn-block {
   padding: 0.5rem 0;
   margin: 0.125rem 0 0;
   font-size: 1rem;
-  color: #212529;
+  color: var(--pf-dark-slate);
   text-align: left;
   list-style: none;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 0.25rem;
@@ -3171,7 +3174,7 @@ input[type=button].btn-block {
   padding: 0.25rem 1.5rem;
   clear: both;
   font-weight: 400;
-  color: #212529;
+  color: var(--pf-dark-slate);
   text-align: inherit;
   white-space: nowrap;
   background-color: transparent;
@@ -3183,7 +3186,7 @@ input[type=button].btn-block {
   background-color: #f8f9fa;
 }
 .dropdown-item.active, .dropdown-item:active {
-  color: #fff;
+  color: var(--pf-white);
   text-decoration: none;
   background-color: #f4623a;
 }
@@ -3209,7 +3212,7 @@ input[type=button].btn-block {
 .dropdown-item-text {
   display: block;
   padding: 0.25rem 1.5rem;
-  color: #212529;
+  color: var(--pf-dark-slate);
 }
 
 .btn-group,
@@ -3509,7 +3512,7 @@ input[type=button].btn-block {
   opacity: 0;
 }
 .custom-control-input:checked ~ .custom-control-label::before {
-  color: #fff;
+  color: var(--pf-white);
   border-color: #f4623a;
   background-color: #f4623a;
 }
@@ -3520,7 +3523,7 @@ input[type=button].btn-block {
   border-color: #fbc2b3;
 }
 .custom-control-input:not(:disabled):active ~ .custom-control-label::before {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #fde9e3;
   border-color: #fde9e3;
 }
@@ -3545,7 +3548,7 @@ input[type=button].btn-block {
   height: 1rem;
   pointer-events: none;
   content: "";
-  background-color: #fff;
+  background-color: var(--pf-white);
   border: #adb5bd solid 1px;
 }
 .custom-control-label::after {
@@ -3613,7 +3616,7 @@ input[type=button].btn-block {
   }
 }
 .custom-switch .custom-control-input:checked ~ .custom-control-label::after {
-  background-color: #fff;
+  background-color: var(--pf-white);
   transform: translateX(0.75rem);
 }
 .custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
@@ -3630,7 +3633,7 @@ input[type=button].btn-block {
   line-height: 1.5;
   color: #495057;
   vertical-align: middle;
-  background: #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
+  background: var(--pf-white) url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
   -webkit-appearance: none;
@@ -3644,7 +3647,7 @@ input[type=button].btn-block {
 }
 .custom-select:focus::-ms-value {
   color: #495057;
-  background-color: #fff;
+  background-color: var(--pf-white);
 }
 .custom-select[multiple], .custom-select[size]:not([size="1"]) {
   height: auto;
@@ -3720,7 +3723,7 @@ input[type=button].btn-block {
   font-weight: 400;
   line-height: 1.5;
   color: #495057;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
 }
@@ -3754,13 +3757,13 @@ input[type=button].btn-block {
   outline: none;
 }
 .custom-range:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
+  box-shadow: 0 0 0 1px var(--pf-white), 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
 }
 .custom-range:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
+  box-shadow: 0 0 0 1px var(--pf-white), 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
 }
 .custom-range:focus::-ms-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
+  box-shadow: 0 0 0 1px var(--pf-white), 0 0 0 0.2rem rgba(244, 98, 58, 0.25);
 }
 .custom-range::-moz-focus-outer {
   border: 0;
@@ -3937,8 +3940,8 @@ input[type=button].btn-block {
 .nav-tabs .nav-link.active,
 .nav-tabs .nav-item.show .nav-link {
   color: #495057;
-  background-color: #fff;
-  border-color: #dee2e6 #dee2e6 #fff;
+  background-color: var(--pf-white);
+  border-color: #dee2e6 #dee2e6 var(--pf-white);
 }
 .nav-tabs .dropdown-menu {
   margin-top: -1px;
@@ -3951,7 +3954,7 @@ input[type=button].btn-block {
 }
 .nav-pills .nav-link.active,
 .nav-pills .show > .nav-link {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
 }
 
@@ -4301,10 +4304,10 @@ input[type=button].btn-block {
 }
 
 .navbar-dark .navbar-brand {
-  color: #fff;
+  color: var(--pf-white);
 }
 .navbar-dark .navbar-brand:hover, .navbar-dark .navbar-brand:focus {
-  color: #fff;
+  color: var(--pf-white);
 }
 .navbar-dark .navbar-nav .nav-link {
   color: rgba(255, 255, 255, 0.5);
@@ -4319,7 +4322,7 @@ input[type=button].btn-block {
 .navbar-dark .navbar-nav .active > .nav-link,
 .navbar-dark .navbar-nav .nav-link.show,
 .navbar-dark .navbar-nav .nav-link.active {
-  color: #fff;
+  color: var(--pf-white);
 }
 .navbar-dark .navbar-toggler {
   color: rgba(255, 255, 255, 0.5);
@@ -4332,10 +4335,10 @@ input[type=button].btn-block {
   color: rgba(255, 255, 255, 0.5);
 }
 .navbar-dark .navbar-text a {
-  color: #fff;
+  color: var(--pf-white);
 }
 .navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {
-  color: #fff;
+  color: var(--pf-white);
 }
 
 .card {
@@ -4344,7 +4347,7 @@ input[type=button].btn-block {
   flex-direction: column;
   min-width: 0;
   word-wrap: break-word;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
@@ -4588,7 +4591,7 @@ input[type=button].btn-block {
   margin-left: -1px;
   line-height: 1.25;
   color: #f4623a;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border: 1px solid #dee2e6;
 }
 .page-link:hover {
@@ -4615,7 +4618,7 @@ input[type=button].btn-block {
 }
 .page-item.active .page-link {
   z-index: 3;
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
@@ -4623,7 +4626,7 @@ input[type=button].btn-block {
   color: #6c757d;
   pointer-events: none;
   cursor: auto;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border-color: #dee2e6;
 }
 
@@ -4692,11 +4695,11 @@ a.badge:hover, a.badge:focus {
 }
 
 .badge-primary {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
 }
 a.badge-primary:hover, a.badge-primary:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #ee3e0d;
 }
 a.badge-primary:focus, a.badge-primary.focus {
@@ -4705,11 +4708,11 @@ a.badge-primary:focus, a.badge-primary.focus {
 }
 
 .badge-secondary {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #6c757d;
 }
 a.badge-secondary:hover, a.badge-secondary:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #545b62;
 }
 a.badge-secondary:focus, a.badge-secondary.focus {
@@ -4718,11 +4721,11 @@ a.badge-secondary:focus, a.badge-secondary.focus {
 }
 
 .badge-success {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #28a745;
 }
 a.badge-success:hover, a.badge-success:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #1e7e34;
 }
 a.badge-success:focus, a.badge-success.focus {
@@ -4731,11 +4734,11 @@ a.badge-success:focus, a.badge-success.focus {
 }
 
 .badge-info {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #17a2b8;
 }
 a.badge-info:hover, a.badge-info:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #117a8b;
 }
 a.badge-info:focus, a.badge-info.focus {
@@ -4744,11 +4747,11 @@ a.badge-info:focus, a.badge-info.focus {
 }
 
 .badge-warning {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #ffc107;
 }
 a.badge-warning:hover, a.badge-warning:focus {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #d39e00;
 }
 a.badge-warning:focus, a.badge-warning.focus {
@@ -4757,11 +4760,11 @@ a.badge-warning:focus, a.badge-warning.focus {
 }
 
 .badge-danger {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #dc3545;
 }
 a.badge-danger:hover, a.badge-danger:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #bd2130;
 }
 a.badge-danger:focus, a.badge-danger.focus {
@@ -4770,11 +4773,11 @@ a.badge-danger:focus, a.badge-danger.focus {
 }
 
 .badge-light {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #f8f9fa;
 }
 a.badge-light:hover, a.badge-light:focus {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #dae0e5;
 }
 a.badge-light:focus, a.badge-light.focus {
@@ -4783,11 +4786,11 @@ a.badge-light:focus, a.badge-light.focus {
 }
 
 .badge-dark {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #343a40;
 }
 a.badge-dark:hover, a.badge-dark:focus {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #1d2124;
 }
 a.badge-dark:focus, a.badge-dark.focus {
@@ -4890,7 +4893,7 @@ a.badge-dark:focus, a.badge-dark.focus {
 
 .alert-warning {
   color: #856404;
-  background-color: #fff3cd;
+  background-color: var(--pf-white)3cd;
   border-color: #ffeeba;
 }
 .alert-warning hr {
@@ -4967,7 +4970,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   flex-direction: column;
   justify-content: center;
   overflow: hidden;
-  color: #fff;
+  color: var(--pf-white);
   text-align: center;
   white-space: nowrap;
   background-color: #f4623a;
@@ -5023,7 +5026,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #f8f9fa;
 }
 .list-group-item-action:active {
-  color: #212529;
+  color: var(--pf-dark-slate);
   background-color: #e9ecef;
 }
 
@@ -5031,7 +5034,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   position: relative;
   display: block;
   padding: 0.75rem 1.25rem;
-  background-color: #fff;
+  background-color: var(--pf-white);
   border: 1px solid rgba(0, 0, 0, 0.125);
 }
 .list-group-item:first-child {
@@ -5045,11 +5048,11 @@ a.badge-dark:focus, a.badge-dark.focus {
 .list-group-item.disabled, .list-group-item:disabled {
   color: #6c757d;
   pointer-events: none;
-  background-color: #fff;
+  background-color: var(--pf-white);
 }
 .list-group-item.active {
   z-index: 2;
-  color: #fff;
+  color: var(--pf-white);
   background-color: #f4623a;
   border-color: #f4623a;
 }
@@ -5201,7 +5204,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #fbc0b0;
 }
 .list-group-item-primary.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #7f331e;
   border-color: #7f331e;
 }
@@ -5215,7 +5218,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #c8cbcf;
 }
 .list-group-item-secondary.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #383d41;
   border-color: #383d41;
 }
@@ -5229,7 +5232,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #b1dfbb;
 }
 .list-group-item-success.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #155724;
   border-color: #155724;
 }
@@ -5243,7 +5246,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #abdde5;
 }
 .list-group-item-info.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #0c5460;
   border-color: #0c5460;
 }
@@ -5257,7 +5260,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #ffe8a1;
 }
 .list-group-item-warning.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #856404;
   border-color: #856404;
 }
@@ -5271,7 +5274,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #f1b0b7;
 }
 .list-group-item-danger.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #721c24;
   border-color: #721c24;
 }
@@ -5285,7 +5288,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #ececf6;
 }
 .list-group-item-light.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #818182;
   border-color: #818182;
 }
@@ -5299,7 +5302,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   background-color: #b9bbbe;
 }
 .list-group-item-dark.list-group-item-action.active {
-  color: #fff;
+  color: var(--pf-white);
   background-color: #1b1e21;
   border-color: #1b1e21;
 }
@@ -5310,7 +5313,7 @@ a.badge-dark:focus, a.badge-dark.focus {
   font-weight: 700;
   line-height: 1;
   color: #000;
-  text-shadow: 0 1px 0 #fff;
+  text-shadow: 0 1px 0 var(--pf-white);
   opacity: 0.5;
 }
 .close:hover {
@@ -5461,7 +5464,7 @@ a.close.disabled {
   flex-direction: column;
   width: 100%;
   pointer-events: auto;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 0.3rem;
@@ -5660,7 +5663,7 @@ a.close.disabled {
 .tooltip-inner {
   max-width: 200px;
   padding: 0.25rem 0.5rem;
-  color: #fff;
+  color: var(--pf-white);
   text-align: center;
   background-color: #000;
   border-radius: 0.25rem;
@@ -5689,7 +5692,7 @@ a.close.disabled {
   line-break: auto;
   font-size: 0.875rem;
   word-wrap: break-word;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 0.3rem;
@@ -5723,7 +5726,7 @@ a.close.disabled {
 .bs-popover-top > .arrow::after, .bs-popover-auto[x-placement^=top] > .arrow::after {
   bottom: 1px;
   border-width: 0.5rem 0.5rem 0;
-  border-top-color: #fff;
+  border-top-color: var(--pf-white);
 }
 
 .bs-popover-right, .bs-popover-auto[x-placement^=right] {
@@ -5743,7 +5746,7 @@ a.close.disabled {
 .bs-popover-right > .arrow::after, .bs-popover-auto[x-placement^=right] > .arrow::after {
   left: 1px;
   border-width: 0.5rem 0.5rem 0.5rem 0;
-  border-right-color: #fff;
+  border-right-color: var(--pf-white);
 }
 
 .bs-popover-bottom, .bs-popover-auto[x-placement^=bottom] {
@@ -5760,7 +5763,7 @@ a.close.disabled {
 .bs-popover-bottom > .arrow::after, .bs-popover-auto[x-placement^=bottom] > .arrow::after {
   top: 1px;
   border-width: 0 0.5rem 0.5rem 0.5rem;
-  border-bottom-color: #fff;
+  border-bottom-color: var(--pf-white);
 }
 .bs-popover-bottom .popover-header::before, .bs-popover-auto[x-placement^=bottom] .popover-header::before {
   position: absolute;
@@ -5790,7 +5793,7 @@ a.close.disabled {
 .bs-popover-left > .arrow::after, .bs-popover-auto[x-placement^=left] > .arrow::after {
   right: 1px;
   border-width: 0.5rem 0 0.5rem 0.5rem;
-  border-left-color: #fff;
+  border-left-color: var(--pf-white);
 }
 
 .popover-header {
@@ -5808,7 +5811,7 @@ a.close.disabled {
 
 .popover-body {
   padding: 0.5rem 0.75rem;
-  color: #212529;
+  color: var(--pf-dark-slate);
 }
 
 .carousel {
@@ -5896,7 +5899,7 @@ a.close.disabled {
   align-items: center;
   justify-content: center;
   width: 15%;
-  color: #fff;
+  color: var(--pf-white);
   text-align: center;
   opacity: 0.5;
   transition: opacity 0.15s ease;
@@ -5910,7 +5913,7 @@ a.close.disabled {
 .carousel-control-prev:hover, .carousel-control-prev:focus,
 .carousel-control-next:hover,
 .carousel-control-next:focus {
-  color: #fff;
+  color: var(--pf-white);
   text-decoration: none;
   outline: 0;
   opacity: 0.9;
@@ -5962,7 +5965,7 @@ a.close.disabled {
   margin-left: 3px;
   text-indent: -999px;
   cursor: pointer;
-  background-color: #fff;
+  background-color: var(--pf-white);
   background-clip: padding-box;
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
@@ -5986,7 +5989,7 @@ a.close.disabled {
   z-index: 10;
   padding-top: 20px;
   padding-bottom: 20px;
-  color: #fff;
+  color: var(--pf-white);
   text-align: center;
 }
 
@@ -6084,17 +6087,17 @@ a.close.disabled {
 a.bg-primary:hover, a.bg-primary:focus,
 button.bg-primary:hover,
 button.bg-primary:focus {
-  background-color: #E2E5F0 !important;
+  background-color: var(--pf-pale-aqua) !important;
 }
 
 .bg-secondary {
-  background-color: white !important;
+  background-color: var(--pf-white) !important;
 }
 
 a.bg-secondary:hover, a.bg-secondary:focus,
 button.bg-secondary:hover,
 button.bg-secondary:focus {
-  background-color: white !important;
+  background-color: var(--pf-white) !important;
 }
 
 .bg-success {
@@ -6138,7 +6141,7 @@ button.bg-danger:focus {
 }
 
 .bg-light {
-  background-color: #E2E5F0 !important;
+  background-color: var(--pf-pale-aqua) !important;
 }
 
 a.bg-light:hover, a.bg-light:focus,
@@ -6158,7 +6161,7 @@ button.bg-dark:focus {
 }
 
 .bg-white {
-  background-color: #fff !important;
+  background-color: var(--pf-white) !important;
 }
 
 .bg-transparent {
@@ -6238,7 +6241,7 @@ button.bg-dark:focus {
 }
 
 .border-white {
-  border-color: #fff !important;
+  border-color: var(--pf-white) !important;
 }
 
 .rounded-sm {
@@ -9819,7 +9822,7 @@ a.text-dark:hover, a.text-dark:focus {
 }
 
 .text-body {
-  color: #212529 !important;
+  color: var(--pf-dark-slate) !important;
 }
 
 .text-muted {
@@ -9934,7 +9937,7 @@ h3 {
   }
   .table td,
 .table th {
-    background-color: #fff !important;
+    background-color: var(--pf-white) !important;
   }
 
   .table-bordered th,
@@ -9966,11 +9969,11 @@ html {
 hr.divider {
   max-width: 3.25rem;
   border-width: 0.2rem;
-  border-color: #A32035;;
+  border-color: var(--pf-deep-aqua);
 }
 
 hr.light {
-  border-color: #fff;
+  border-color: var(--pf-white);
 }
 
 .btn {
@@ -9999,18 +10002,18 @@ hr.light {
 #mainNav .navbar-brand {
   font-family: "Merriweather Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
-  color: #212529;
+  color: var(--pf-dark-slate);
 }
 #mainNav .navbar-nav .nav-item .nav-link {
   padding-right: 20px;
-  color: #071E3C;
+  color: var(--pf-forest-blue);
   font-family: "Merriweather Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
   font-size: 0.9rem;
   padding: 0.75rem 0;
 }
 #mainNav .navbar-nav .nav-item .nav-link:hover, #mainNav .navbar-nav .nav-item .nav-link:active {
-  color: #5472B6;
+  color: var(--pf-deep-aqua);
 }
 #mainNav .navbar-nav .nav-item .nav-link.active {
   color: #f4623a !important;
@@ -10023,30 +10026,30 @@ hr.light {
     color: rgba(255, 255, 255, 0.7);
   }
   #mainNav .navbar-brand:hover {
-    color: #fff;
+    color: var(--pf-white);
   }
   #mainNav .navbar-nav .nav-item .nav-link {
     color: rgb(12, 30, 58);
     padding: 0 1rem;
   }
   #mainNav .navbar-nav .nav-item .nav-link:hover {
-    color: #5472B6;
+    color: var(--pf-deep-aqua);
   }
   #mainNav .navbar-nav .nav-item:last-child .nav-link {
     padding-right: 0;
   }
   #mainNav.navbar-scrolled {
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-    background-color: #fff;
+    background-color: var(--pf-white);
   }
   #mainNav.navbar-scrolled .navbar-brand {
-    color: #212529;
+    color: var(--pf-dark-slate);
   }
   #mainNav.navbar-scrolled .navbar-brand:hover {
     color: #f4623a;
   }
   #mainNav.navbar-scrolled .navbar-nav .nav-item .nav-link {
-    color: #212529;
+    color: var(--pf-dark-slate);
   }
   #mainNav.navbar-scrolled .navbar-nav .nav-item .nav-link:hover {
     color: #f4623a;
@@ -10054,7 +10057,7 @@ hr.light {
 }
 
 header.masthead {
-  background-color: #E2E5F0;
+  background-color: var(--pf-pale-aqua);
   color: rgb(12, 30, 58);
   padding-top: 8rem;
   padding-bottom: calc(10rem - 4.5rem);
@@ -10103,7 +10106,7 @@ header.masthead h1 {
   bottom: 0;
   text-align: center;
   opacity: 0;
-  color: #fff;
+  color: var(--pf-white);
   background: rgba(244, 98, 58, 0.9);
   transition: opacity 0.25s ease;
   text-align: center;
@@ -10212,11 +10215,11 @@ header.masthead  {
 
 .socials {
   cursor: pointer;
-  color: #071E3C;
+  color: var(--pf-forest-blue);
 }
 
 .socials svg:hover {
-  color: #5472B6;
+  color: var(--pf-deep-aqua);
 }
 
 .centered {
@@ -10228,7 +10231,7 @@ header.masthead  {
   position: absolute;
   top: -0;
   right: -0;
-  background: white;
+  background: var(--pf-white);
   padding: 8px;
   border-radius: 0 0 0 4px;
   opacity: 0.8;


### PR DESCRIPTION
Replaces all usage of our preview palette, as well as any default bootstrap usage of colors that are very similar. Used CSS variables so we can reuse/change more easily. Click-tested around the local site with this and didn't notice anything ugly.