### PR TITLE
Make apply buttons less janky

### DIFF
--- a/_includes/apply.html
+++ b/_includes/apply.html
@@ -1,32 +1,28 @@
-<section class="page-section call-to-action">
-  <div class="container">
-    <h2 class="mt-5 mb-5 text-center">{% translate apply.title %}</h2>
-    <div class="row">
-      <div class="col-12 col-lg-12 mb-4">
-        {% for p in site.translations[site.lang]["apply"]["overview_content"] %}
-        <p>{{ p }}</p>
-        {% endfor %}
-      </div>
+<section class="page-section">
+  <h2 class="mt-5 mb-5 text-center">{% translate apply.title %}</h2>
+  <div class="row justify-content-center">
+    <div class="col-10 col-md-9 col-lg-8 col-xl-6 mb-4">
+      {% for p in site.translations[site.lang]["apply"]["overview_content"] %}
+      <p>{{ p }}</p>
+      {% endfor %}
     </div>
-    {% include apply_buttons.html %}
   </div>
+  {% include apply_buttons.html %}
 </section>
 
 <section class="page-section bg-secondary">
-  <div class="container">
-    <div class="row">
-      <div class="col-12 col-lg-12">
-        <h2 class="mb-5 centered">{% translate apply.faq_title %}</h2>
-        {% for qa in site.translations[site.lang]["apply"]["faq_content"] %}
-        <h5 class="mb-3 mt-5">
-          {{ qa[0] }}
-        </h5>
-        {% for answer in qa[1] %}
-        <p class="font-weight-light">{{ answer }}</p>
-        {% endfor %}
-        {% endfor %}
-      </div>
+  <div class="row justify-content-center">
+    <div class="col-10 col-md-9 col-lg-8 col-xl-6">
+      <h2 class="mb-5 centered">{% translate apply.faq_title %}</h2>
+      {% for qa in site.translations[site.lang]["apply"]["faq_content"] %}
+      <h5 class="mb-3 mt-5">
+        {{ qa[0] }}
+      </h5>
+      {% for answer in qa[1] %}
+      <p class="font-weight-light">{{ answer }}</p>
+      {% endfor %}
+      {% endfor %}
     </div>
-    {% include apply_buttons.html %}
   </div>
+  {% include apply_buttons.html %}
 </section>

--- a/_includes/apply_buttons.html
+++ b/_includes/apply_buttons.html
@@ -1,11 +1,11 @@
 <div class="row justify-content-center">
-  <div class="col-4 align-self-baseline">
-    <a class="btn btn-dark btn-xl js-scroll-trigger"
+  <div class="col-8 col-lg-3 justify-content-center text-center">
+    <a class="btn btn-dark btn-xl js-scroll-trigger mb-3 mb-lg-0"
        href="https://fund.uptogether.org/kingcounty-code">
       {% translate apply.button_code %}
     </a>
   </div>
-  <div class="col-4 align-self-baseline">
+  <div class="col-8 col-lg-3 justify-content-center text-center">
     <a class="btn btn-dark btn-xl js-scroll-trigger"
        href="https://fund.uptogether.org/kingcounty">
       {% translate apply.button_no_code %}


### PR DESCRIPTION
This should address issue #15, reported by Rajiv:

> “Apply With Code” and “Apply Without a Code” CTA buttons need to be centered on the page at the top and below after the FAQ. Right now they are set to the left.

Tested locally on mobile and desktop sizes, looks OK. Note that this positions the buttons one on top of the other on mobile, and transitions to side-by-side at the `lg` break point.