### PR TITLE
Speed up docker build installing gems first and caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jekyll/jekyll
+
+COPY Gemfile* /usr/local/bundle/
+WORKDIR /usr/local/bundle
+RUN bundle install
+WORKDIR /srv/jekyll

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Covid Response Fund Site
+# The Plate Fund Site
 
 ## Development
 
@@ -10,6 +10,9 @@ docker-compose up
 
 This will run `jekyll serve` in a docker container, which will monitor files for changes
 and serve the site at http://locahost:4000.
+
+
+Note: if you add Gems, you may need to rebuild the docker image using `docker-compose build` or `docker-compose up --build`.
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   jekyll:
-    image: jekyll/jekyll
+    build: .
     command: jekyll serve
     volumes:
       - .:/srv/jekyll


### PR DESCRIPTION
I've been annoyed when recreating the docker container that the gems take a long time to install. Docker is good about caching stuff like that, so let's leverage it.

`docker-compose up` as usual should now build the image the first time, then cache the gems. It should only need to be rebuilt if gems are added.