### PR TITLE
Fix regression of photo placement on mobile

### DIFF
--- a/_includes/stories.html
+++ b/_includes/stories.html
@@ -12,10 +12,11 @@
       {% for story in site.translations["en"]["home"]["stories"] %}
       <div class="col-6 col-sm-6 col-md-6 col-lg-3 mb-2">
         {% assign img = story[1]["name"] | prepend: site.image_base_url %}
-        <picture style="width: 100%">
+        <picture>
           <source srcset="{{ img | append: '.webp'}}" type="image/webp">
           <source srcset="{{ img | append: '.jpg'}}" type="image/jpeg">
-          <img src="{{ img | append: '.jpg' }}" alt="{{ story[0] }}" />
+          <img src="{{ img | append: '.jpg' }}" alt="{{ story[0] }}" style="width: 100%"/>
+        </picture>
       </div>
       <div class="col-6 col-sm-6 col-md-6 col-lg-3">
         <strong>{{ story[0] }}</strong>


### PR DESCRIPTION
Looks like https://github.com/amperity/plate-fund-site/pull/23 broke the "Their stories" images:

![Screen Shot 2020-04-07 at 11 26 26 PM](https://user-images.githubusercontent.com/3165665/78751505-3a7a4b00-7927-11ea-8b6b-e3db698eb833.png)

This seems to fix it locally.