### PR TITLE
Optimize google fonts use: single request, swap for fout

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,8 +29,7 @@
     }
 </script>
   <!-- Google fonts-->
-  <link href="https://fonts.googleapis.com/css?family=Merriweather+Sans:400,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather+Sans:wght@400;700&family=Merriweather:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
   <!-- Core theme CSS (includes Bootstrap)-->
   <link href="{{ "/css/styles.css" | prepend: site.baseurl_root }}" rel="stylesheet" />
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "/favicon.png" | prepend: site.baseurl_root }}" />


### PR DESCRIPTION
This should further speed up our page load and reduce our time before first paint. It does two major things:
- Makes a single google fonts request instead of two (while still retrieving the same fonts)
- Adds a &display=swap option to prefer FOUT (flash of unstyled text) while loading the font. This means that, on a slow connection, the user will see content faster though it won't immediately be in the proper font.